### PR TITLE
add cross-table ID to hierarchical micro data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,5 +47,7 @@ Suggests:
     shiny,
     testthat,
     covr
+SystemRequirements:
+    C++11,
 VignetteBuilder: knitr
 LinkingTo: Rcpp

--- a/R/micro_read.r
+++ b/R/micro_read.r
@@ -307,8 +307,9 @@ read_raw_to_df_list <- function(raw, rec_vinfo, all_vars, encoding) {
   names(out) <- names(vars_by_rt)
 
   for (rt in names(vars_by_rt)) {
-    names(out[[rt]]) <- vars_by_rt[[rt]]$var_name
+    names(out[[rt]]) <- c ("ID", vars_by_rt[[rt]]$var_name)
     out[[rt]] <- tibble::as_tibble(out[[rt]])
+    out[[rt]]$ID <- as.integer (out[[rt]]$ID)
 
     numeric_vars <- vars_by_rt[[rt]]$var_name[vars_by_rt[[rt]]$var_type == "numeric"]
     out[[rt]] <- dplyr::mutate_at(out[[rt]], numeric_vars, readr::parse_number)

--- a/src/read_hier_list.cpp
+++ b/src/read_hier_list.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include <Rcpp.h>
 using namespace Rcpp;
 

--- a/src/read_hier_list.cpp
+++ b/src/read_hier_list.cpp
@@ -48,10 +48,12 @@ RObject raw_to_df_hier_list(
   std::vector<std::vector <std::vector <std::string> > > out;
   out.resize(num_rt);
   for (int i = 0; i < num_rt; i++) {
-    out[i].resize(num_vars_rectype[i]);
+    out[i].resize(num_vars_rectype[i] + 1); // Add cross-record ID
   }
 
   // Parse raw into list
+  size_t id = 1; // 1-based for R
+  int rt_index_first = -1;
   for (int i = 0; i < num_rows; i++) {
     if (i % 1000000 == 0) {
       Rcpp::checkUserInterrupt();
@@ -76,18 +78,26 @@ RObject raw_to_df_hier_list(
       break;
     }
 
+    if (i == 0) {
+        rt_index_first = rt_index;
+    } else if (rt_index == rt_index_first) {
+      id++;
+    }
+
     // Check if raw line is long enough
     if (Rf_length(raw[i]) < max_ends[rt_index]) {
       Rcpp::stop("Line is too short for rectype.");
     }
 
+    // Add ID to out
+    out[rt_index][0].push_back (std::to_string (id));
     // Loop through vars in rectype and add to out
     for (int j = 0; j < num_vars_rectype[rt_index]; j++) {
       Rbyte* cur_text_pos = row_raw + starts[rt_index][j];
       int cur_var_width = widths[rt_index][j];
       std::string cur_text = as<std::string>(Rf_mkCharLenCE((const char*)cur_text_pos, cur_var_width, encoding_ce));
 
-      out[rt_index][j].push_back(cur_text);
+      out[rt_index][j + 1].push_back(cur_text);
     }
   }
 

--- a/tests/testthat/test_micro.r
+++ b/tests/testthat/test_micro.r
@@ -87,8 +87,8 @@ test_that(
 
     expect_equal(nrow(cps$HOUSEHOLD), rows_h)
     expect_equal(nrow(cps$PERSON), rows_p)
-    expect_equal(ncol(cps$HOUSEHOLD), vars_h)
-    expect_equal(ncol(cps$PERSON), vars_p)
+    expect_equal(ncol(cps$HOUSEHOLD), vars_h + 1) # + 1 for cross-record ID
+    expect_equal(ncol(cps$PERSON), vars_p + 1) # ditto
     expect_equal(attr(cps$HOUSEHOLD[["YEAR"]], "label"), YEAR_label)
     expect_equal(attr(cps$PERSON[["YEAR"]], "label"), YEAR_label)
     expect_equal(attr(cps$HOUSEHOLD[["YEAR"]], "var_desc"), YEAR_var_desc)


### PR DESCRIPTION
hey @gergness, sorry about total lack of contribution to date. excuses, excuses, blah blah, but first things first: Congratulations on pulling together an amazing, and amazingly well-coded, package! You've really done a brilliant job. I particularly like the way you first read in the binary data into R and then pass (the implicit pointer to) that to the C++ routines - sure, it might be marginally more efficient to do the whole shebang in C++, but you gain so much more flexibility your way. It really is very clever.

Motivation for the PR: It appears to me - and it is very likely that i may be wrong here, so please let me know if so! - that it is not currently possible to cross-reference hierarchical micro data, because the tables contain no way to match entries. This PR is an attempt by me to implement one way of achieving this, by way of a shared "ID" variable. I'm very happy to have a conversation here before you accept this PR, particularly if I have actually misunderstood the results of `read_ipums_micro_list` - just let me know.

My current way of looking at this:
```
dat <- read_ipums_micro_list (ipums_example("cps_00010.xml")) 
```
How do I match variables in `dat$PERSON` to corresponding ones in `dat$HOUSEHOLD`? For example, what is the `STATEFIP` OF `dat$PERSON [1, ]`? Such matching is necessary to actually analyse the data in a hierarchical fashion, right?

The PR can also be re-phrased in direct R terms: I've attempted to create a variable that can be used directly for `dplyr` table joins, because it seems to me that current tables do not have any variables with which to do this?

-------

I also had a play around with efficiency gains in `read_hier_list.cpp`, by way of properly pre-allocating your `out` array (your comment about you being, "not sure if this is a performant way to do this"), but it didn't bring anything. The info you need to pre-allocate can't be extracted efficiently from `readr::read_lines_raw`, and real efficiency gains would only be possible by doing this in C++, at the expense of the aforementioned loss of flexibility.