### PR TITLE
Dplyr 1.0.0

### DIFF
--- a/R/bind_rows.r
+++ b/R/bind_rows.r
@@ -32,33 +32,22 @@ ipums_bind_rows <- function(..., .id = NULL) {
   })
   names(attrs_by_var) <- unique_var_names
 
-  purrr::iwalk(purrr::keep(attrs_by_var, ~!is_FALSE(.)), function(attr, vname) {
-    for (iii in seq_along(d_list)) {
-      if (vname %in% names(d_list[[iii]])) {
-        d_list[[iii]][[vname]] <<- zap_ipums_attributes(d_list[[iii]][[vname]])
-      }
-    }
-  })
+  # Remove all IPUMS attributes (we will put back the matching ones after
+  # row-binding)
+  d_list <- purrr::map(d_list, zap_ipums_attributes)
 
-  # Remove all attributes for shared columns with incompatible attributes
   vars_w_incompat_attrs <- unique_var_names[purrr::map_lgl(attrs_by_var, ~ is_FALSE(.))]
   if (length(vars_w_incompat_attrs) > 0) {
     warning(
-      "All attributes have been removed from the following columns, which ",
+      "IPUMS attributes have been removed from the following columns, which ",
       "had incompatible attributes across the data.frames to be combined: ",
       paste0(vars_w_incompat_attrs, collapse = ",")
     )
-    purrr::iwalk(purrr::keep(attrs_by_var, ~is_FALSE(.)), function(attr, vname) {
-      for (iii in seq_along(d_list)) {
-        if (vname %in% names(d_list[[iii]])) {
-          attributes(d_list[[iii]][[vname]]) <<- NULL
-        }
-      }
-    })
   }
 
   out <- dplyr::bind_rows(d_list, .id = .id)
 
+  # Reassign attributes for columns where all attributes matched
   purrr::iwalk(purrr::keep(attrs_by_var, ~!is_FALSE(.)), function(attr, vname) {
     attributes(out[[vname]]) <<- attr
   })

--- a/R/bind_rows.r
+++ b/R/bind_rows.r
@@ -40,6 +40,23 @@ ipums_bind_rows <- function(..., .id = NULL) {
     }
   })
 
+  # Remove all attributes for shared columns with incompatible attributes
+  vars_w_incompat_attrs <- unique_var_names[purrr::map_lgl(attrs_by_var, ~ is_FALSE(.))]
+  if (length(vars_w_incompat_attrs) > 0) {
+    warning(
+      "All attributes have been removed from the following columns, which ",
+      "had incompatible attributes across the data.frames to be combined: ",
+      paste0(vars_w_incompat_attrs, collapse = ",")
+    )
+    purrr::iwalk(purrr::keep(attrs_by_var, ~is_FALSE(.)), function(attr, vname) {
+      for (iii in seq_along(d_list)) {
+        if (vname %in% names(d_list[[iii]])) {
+          attributes(d_list[[iii]][[vname]]) <<- NULL
+        }
+      }
+    })
+  }
+
   out <- dplyr::bind_rows(d_list, .id = .id)
 
   purrr::iwalk(purrr::keep(attrs_by_var, ~!is_FALSE(.)), function(attr, vname) {

--- a/R/callbacks.r
+++ b/R/callbacks.r
@@ -7,7 +7,7 @@
 #'
 #' These classes are used to define callback behaviors that have been adapted
 #' for use on IPUMS microdata extracts. Though the callbacks from the
-#' readr package will work, they will not take divide out implicit decimals
+#' readr package will work, they will not handle implicit decimals
 #' or add value/variable labels to the data.
 #'
 #' \describe{

--- a/R/lbl_helpers.r
+++ b/R/lbl_helpers.r
@@ -399,7 +399,7 @@ as_lbl_function <- function(x, env = caller_env()) {
 
 # Adapted from rlang:::abort_coercion
 abort_coercion_function <- function(x) {
-  x_type <- rlang::friendly_type_of(x)
+  x_type <- rlang:::friendly_type_of(x)
   abort(paste0("Can't convert ", x_type, " to function"))
 }
 

--- a/R/lbl_helpers.r
+++ b/R/lbl_helpers.r
@@ -399,8 +399,40 @@ as_lbl_function <- function(x, env = caller_env()) {
 
 # Adapted from rlang:::abort_coercion
 abort_coercion_function <- function(x) {
-  x_type <- rlang:::friendly_type_of(x)
+  x_type <- friendly_type_of(x)
   abort(paste0("Can't convert ", x_type, " to function"))
+}
+
+# Copied from rlang:::friendly_type_of()
+friendly_type_of <- function(x, length = FALSE) {
+  if (is.object(x)) {
+    return(sprintf("a `%s` object", paste(class(x),
+                                          collapse = "/")))
+  }
+  friendly <- as_friendly_type(typeof(x))
+  if (length && rlang::is_vector(x)) {
+    friendly <- paste0(friendly, sprintf(" of length %s",
+                                         length(x)))
+  }
+  friendly
+}
+
+# Copied from rlang:::as_friendly_type()
+as_friendly_type <- function(type) {
+  switch(type, logical = "a logical vector", integer = "an integer vector",
+         numeric = , double = "a double vector", complex = "a complex vector",
+         character = "a character vector", raw = "a raw vector",
+         string = "a string", list = "a list", `NULL` = "NULL",
+         environment = "an environment", externalptr = "a pointer",
+         weakref = "a weak reference", S4 = "an S4 object",
+         name = , symbol = "a symbol", language = "a call",
+         pairlist = "a pairlist node", expression = "an expression vector",
+         quosure = "a quosure", formula = "a formula",
+         char = "an internal string", promise = "an internal promise",
+         ... = "an internal dots object", any = "an internal `any` object",
+         bytecode = "an internal bytecode object", primitive = ,
+         builtin = , special = "a primitive function", closure = "a function",
+         type)
 }
 
 #' Make a label placeholder object

--- a/man/ipums_callback.Rd
+++ b/man/ipums_callback.Rd
@@ -11,7 +11,7 @@
 \description{
 These classes are used to define callback behaviors that have been adapted
 for use on IPUMS microdata extracts. Though the callbacks from the
-readr package will work, they will not take divide out implicit decimals
+readr package will work, they will not handle implicit decimals
 or add value/variable labels to the data.
 }
 \details{


### PR DESCRIPTION
The only change of much substance here is to take over some work that was previously done by `dplyr::bind_rows()` and incorporate it into `ipumsr::ipums_bind_rows()`. Specifically, `dplyr::bind_rows()` used to remove incompatible attributes with a warning, but now it throws an error instead, so I added code to `ipumsr::ipums_bind_rows()` that removes all attributes from columns with any incompatible attributes and warns the user.