### PR TITLE
Lower vars

### DIFF
--- a/R/ddi_read.r
+++ b/R/ddi_read.r
@@ -15,7 +15,7 @@
 #'   \code{\link[dplyr]{select}}-style notation indicating which .xml data
 #'   layer to load.
 #' @param lower_vars Logical indicating whether to convert variable names
-#'   to lowercase (default is FALSE due to tradition)
+#'   to lowercase (default is FALSE, in line with IPUMS conventions)
 #' @return An \code{ipums_ddi} object with metadata information.
 #' @examples
 #' # Example extract DDI
@@ -132,8 +132,10 @@ read_ipums_ddi <- function(ddi_file, data_layer = NULL, lower_vars = FALSE) {
 
   if (lower_vars) {
     var_info$var_name <- tolower(var_info$var_name)
-    rectype_idvar <- tolower(rectype_idvar)
-    rectypes_keyvars$keyvars <- purrr::map(rectypes_keyvars$keyvars, tolower)
+    if (!is.null(rectype_idvar)) rectype_idvar <- tolower(rectype_idvar)
+    if (!is.null(rectypes_keyvars)) {
+      rectypes_keyvars$keyvars <- purrr::map(rectypes_keyvars$keyvars, tolower)
+    }
   }
 
   make_ddi_from_scratch(

--- a/R/micro_read.r
+++ b/R/micro_read.r
@@ -210,7 +210,7 @@ read_ipums_micro_list <- function(
 #' to a data reading function
 #' @noRd
 check_if_lower_vars_ignored <- function(ddi, lower_vars) {
-  "ipums_ddi" %in% class(ddi) & lower_vars
+  inherits(ddi, "ipums_ddi") & lower_vars
 }
 
 lower_vars_ignored_warning <- function() {

--- a/R/micro_read.r
+++ b/R/micro_read.r
@@ -210,7 +210,7 @@ read_ipums_micro_list <- function(
 #' to a data reading function
 #' @noRd
 check_if_lower_vars_ignored <- function(ddi, lower_vars) {
-  is(ddi, "ipums_ddi") & lower_vars
+  "ipums_ddi" %in% class(ddi) & lower_vars
 }
 
 lower_vars_ignored_warning <- function() {

--- a/R/micro_read.r
+++ b/R/micro_read.r
@@ -47,9 +47,12 @@
 #' @param var_attrs Variable attributes to add from the DDI, defaults to
 #'   adding all (val_labels, var_label and var_desc). See
 #'   \code{\link{set_ipums_var_attributes}} for more details.
-#' @param lower_vars If reading a DDI from a file, a logical indicating
-#'   whether to convert variable names to lowercase (default is FALSE due
-#'   to tradition)
+#' @param lower_vars Only if reading a DDI from a file, a logical indicating
+#'   whether to convert variable names to lowercase (default is FALSE, in line
+#'   with IPUMS conventions). Note that this argument will be ignored if
+#'   argument \code{ddi} is an \code{ipums_ddi} object rather than a file path.
+#'   See \code{\link{read_ipums_ddi}} for converting variable names to lowercase
+#'   when reading in the DDI.
 #' @return \code{read_ipums_micro} returns a single tbl_df data frame, and
 #'   \code{read_ipums_micro_list} returns a list of data frames, named by
 #'   the Record Type. See 'Details' for more
@@ -91,6 +94,10 @@ read_ipums_micro <- function(
   var_attrs = c("val_labels", "var_label", "var_desc"),
   lower_vars = FALSE
 ) {
+  lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
+  if (lower_vars_was_ignored) {
+    warning(lower_vars_ignored_warning())
+  }
   if (is.character(ddi)) ddi <- read_ipums_ddi(ddi, lower_vars = lower_vars)
   if (is.null(data_file)) data_file <- file.path(ddi$file_path, ddi$file_name)
 
@@ -113,6 +120,9 @@ read_ipums_micro <- function(
       locale = ipums_locale(ddi$file_encoding),
       progress = show_readr_progress(verbose)
     )
+    if (ddi_has_lowercase_var_names(ddi)) {
+      out <- dplyr::rename_all(out, tolower)
+    }
   } else {
     rt_info <- ddi_to_rtinfo(ddi)
     col_spec <- ddi_to_colspec(ddi, "long", verbose)
@@ -142,6 +152,10 @@ read_ipums_micro_list <- function(
   var_attrs = c("val_labels", "var_label", "var_desc"),
   lower_vars = FALSE
 ) {
+  lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
+  if (lower_vars_was_ignored) {
+    warning(lower_vars_ignored_warning())
+  }
   if (is.character(ddi)) ddi <- read_ipums_ddi(ddi, lower_vars = lower_vars)
   if (is.null(data_file)) data_file <- file.path(ddi$file_path, ddi$file_name)
 
@@ -166,6 +180,9 @@ read_ipums_micro_list <- function(
       locale = ipums_locale(ddi$file_encoding),
       progress = show_readr_progress(verbose)
     )
+    if (ddi_has_lowercase_var_names(ddi)) {
+      out <- dplyr::rename_all(out, tolower)
+    }
     if (verbose) cat("Assuming data rectangularized to 'P' record type")
     out <- list("P" = out)
   } else {
@@ -189,3 +206,18 @@ read_ipums_micro_list <- function(
   out
 }
 
+#' Warns the user that lower_vars has been ignored when they supply an ipums_ddi
+#' to a data reading function
+#' @noRd
+check_if_lower_vars_ignored <- function(ddi, lower_vars) {
+  is(ddi, "ipums_ddi") & lower_vars
+}
+
+lower_vars_ignored_warning <- function() {
+  paste0(
+    "Argument lower_vars was set to TRUE but has been ignored because ",
+    "argument ddi is an ipums_ddi object. To obtain lowercase names in both ",
+    "the ipums_ddi object and the data, set lower_vars to TRUE in your call ",
+    "to function `read_ipums_ddi`."
+  )
+}

--- a/R/micro_read_helpers.r
+++ b/R/micro_read_helpers.r
@@ -109,7 +109,7 @@ ddi_to_readr_colspec <- function(ddi) {
     else if (x == "integer") out <- readr::col_integer()
     out
   })
-  names(col_types) <- ddi$var_info$var_name
+  names(col_types) <- toupper(ddi$var_info$var_name)
   col_types <- do.call(readr::cols_only, col_types)
 }
 
@@ -129,4 +129,8 @@ rectype_label_names <- function(cur_names, ddi) {
   rt_lbls <- fostr_replace_all(rt_lbls, "[[:blank:]]", "_")
 
   rt_lbls
+}
+
+ddi_has_lowercase_var_names <- function(ddi) {
+  all(ddi$var_info$var_name == tolower(ddi$var_info$var_name))
 }

--- a/R/micro_read_yield.r
+++ b/R/micro_read_yield.r
@@ -11,7 +11,9 @@
 #' the functions like \code{\link{read_ipums_micro_chunked}}, allowing
 #' you to do things like reading parts of multiple files at the same time
 #' and resetting from the beginning more easily than with the chunked
-#' functions.
+#' functions. \strong{Note that while other \code{read_ipums_micro*} functions
+#' can read from .csv(.gz) or .dat(.gz) files, these functions can only read
+#' from .dat(.gz) files.}
 #'
 #' These functions return an IpumsYield R6 object which have the following
 #' methods:
@@ -115,8 +117,18 @@ IpumsLongYield <- R6::R6Class(
       var_attrs = c("val_labels", "var_label", "var_desc"),
       lower_vars = FALSE
     ) {
+      lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
+      if (lower_vars_was_ignored) {
+        warning(lower_vars_ignored_warning())
+      }
       if (is.character(ddi)) ddi <- read_ipums_ddi(ddi, lower_vars = lower_vars)
       if (is.null(data_file)) data_file <- file.path(ddi$file_path, ddi$file_name)
+      if (fostr_detect(data_file, "\\.csv$|\\.csv\\.gz$")) {
+        stop(
+          "read_ipums_micro_yield does not support reading from .csv ",
+          "formatted data files, only from .dat (or .dat.gz) files"
+        )
+      }
 
       data_file <- custom_check_file_exists(data_file, c(".dat.gz", ".csv", ".csv.gz"))
 
@@ -164,8 +176,18 @@ IpumsListYield <- R6::R6Class(
       var_attrs = c("val_labels", "var_label", "var_desc"),
       lower_vars = FALSE
     ) {
+      lower_vars_was_ignored <- check_if_lower_vars_ignored(ddi, lower_vars)
+      if (lower_vars_was_ignored) {
+        warning(lower_vars_ignored_warning())
+      }
       if (is.character(ddi)) ddi <- read_ipums_ddi(ddi, lower_vars = lower_vars)
       if (is.null(data_file)) data_file <- file.path(ddi$file_path, ddi$file_name)
+      if (fostr_detect(data_file, "\\.csv$|\\.csv\\.gz$")) {
+        stop(
+          "read_ipums_micro_yield does not support reading from .csv ",
+          "formatted data files, only from .dat (or .dat.gz) files"
+        )
+      }
 
       data_file <- custom_check_file_exists(data_file, c(".dat.gz", ".csv", ".csv.gz"))
 

--- a/man/read_ipums_ddi.Rd
+++ b/man/read_ipums_ddi.Rd
@@ -14,7 +14,7 @@ read_ipums_ddi(ddi_file, data_layer = NULL, lower_vars = FALSE)
 layer to load.}
 
 \item{lower_vars}{Logical indicating whether to convert variable names
-to lowercase (default is FALSE due to tradition)}
+to lowercase (default is FALSE, in line with IPUMS conventions)}
 }
 \value{
 An \code{ipums_ddi} object with metadata information.

--- a/man/read_ipums_micro.Rd
+++ b/man/read_ipums_micro.Rd
@@ -45,9 +45,12 @@ to console.}
 adding all (val_labels, var_label and var_desc). See
 \code{\link{set_ipums_var_attributes}} for more details.}
 
-\item{lower_vars}{If reading a DDI from a file, a logical indicating
-whether to convert variable names to lowercase (default is FALSE due
-to tradition)}
+\item{lower_vars}{Only if reading a DDI from a file, a logical indicating
+whether to convert variable names to lowercase (default is FALSE, in line
+with IPUMS conventions). Note that this argument will be ignored if
+argument \code{ddi} is an \code{ipums_ddi} object rather than a file path.
+See \code{\link{read_ipums_ddi}} for converting variable names to lowercase
+when reading in the DDI.}
 }
 \value{
 \code{read_ipums_micro} returns a single tbl_df data frame, and

--- a/man/read_ipums_micro_chunked.Rd
+++ b/man/read_ipums_micro_chunked.Rd
@@ -12,7 +12,8 @@ read_ipums_micro_chunked(
   vars = NULL,
   data_file = NULL,
   verbose = TRUE,
-  var_attrs = c("val_labels", "var_label", "var_desc")
+  var_attrs = c("val_labels", "var_label", "var_desc"),
+  lower_vars = FALSE
 )
 
 read_ipums_micro_list_chunked(
@@ -22,7 +23,8 @@ read_ipums_micro_list_chunked(
   vars = NULL,
   data_file = NULL,
   verbose = TRUE,
-  var_attrs = c("val_labels", "var_label", "var_desc")
+  var_attrs = c("val_labels", "var_label", "var_desc"),
+  lower_vars = FALSE
 )
 }
 \arguments{
@@ -49,6 +51,16 @@ to console.}
 \item{var_attrs}{Variable attributes to add from the DDI, defaults to
 adding all (val_labels, var_label and var_desc). See
 \code{\link{set_ipums_var_attributes}} for more details.}
+
+\item{lower_vars}{Only if reading a DDI from a file, a logical indicating
+whether to convert variable names to lowercase (default is FALSE, in line
+with IPUMS conventions). Note that this argument will be ignored if
+argument \code{ddi} is an \code{ipums_ddi} object rather than a file path.
+See \code{\link{read_ipums_ddi}} for converting variable names to lowercase
+when reading in the DDI. Also note that if reading in chunks from a .csv or
+.csv.gz file, the callback function will be called *before* variable names
+are converted to lowercase, and thus should reference uppercase variable
+names.}
 }
 \value{
 Depends on the callback object

--- a/man/read_ipums_micro_yield.Rd
+++ b/man/read_ipums_micro_yield.Rd
@@ -43,9 +43,12 @@ to console.}
 adding all (val_labels, var_label and var_desc). See
 \code{\link{set_ipums_var_attributes}} for more details.}
 
-\item{lower_vars}{If reading a DDI from a file, a logical indicating
-whether to convert variable names to lowercase (default is FALSE due
-to tradition)}
+\item{lower_vars}{Only if reading a DDI from a file, a logical indicating
+whether to convert variable names to lowercase (default is FALSE, in line
+with IPUMS conventions). Note that this argument will be ignored if
+argument \code{ddi} is an \code{ipums_ddi} object rather than a file path.
+See \code{\link{read_ipums_ddi}} for converting variable names to lowercase
+when reading in the DDI.}
 }
 \value{
 A HipYield R6 object (See 'Details' for more information)
@@ -57,7 +60,9 @@ This is a more flexible way to read data in chunks than
 the functions like \code{\link{read_ipums_micro_chunked}}, allowing
 you to do things like reading parts of multiple files at the same time
 and resetting from the beginning more easily than with the chunked
-functions.
+functions. \strong{Note that while other \code{read_ipums_micro*} functions
+can read from .csv(.gz) or .dat(.gz) files, these functions can only read
+from .dat(.gz) files.}
 }
 \details{
 These functions return an IpumsYield R6 object which have the following

--- a/tests/testthat/test_lower_names.R
+++ b/tests/testthat/test_lower_names.R
@@ -40,6 +40,12 @@ test_that(
     # Data is the same except for names
     names(rect_regular) <- tolower(names(rect_regular))
     expect_equal(rect_regular, rect_lower)
+
+    # Also should work when you set lower_vars when reading the DDI
+    ddi <- read_ipums_ddi(ipums_example("cps_00006.xml"), lower_vars = TRUE)
+    data <- read_ipums_micro(ddi, verbose = FALSE)
+
+    expect_equal(names(data), tolower(names(data)))
   })
 
 test_that(
@@ -58,4 +64,285 @@ test_that(
     names(hier_regular[[1]]) <- tolower(names(hier_regular[[1]]))
     names(hier_regular[[2]]) <- tolower(names(hier_regular[[2]]))
     expect_equal(hier_regular, hier_lower)
+
+    # Also should work when you set lower_vars when reading the DDI
+    ddi <- read_ipums_ddi(ipums_example("cps_00010.xml"), lower_vars = TRUE)
+    data <- read_ipums_micro_list(ddi, verbose = FALSE)
+
+    expect_equal(names(data$PERSON), tolower(names(data$PERSON)))
   })
+
+test_that("lower_vars = TRUE warning on rectangular .dat.gz", {
+  ddi <- read_ipums_ddi(ipums_example("cps_00006.xml"))
+
+  expect_warning(
+    data <- read_ipums_micro(ddi, verbose = FALSE, lower_vars = TRUE),
+    regexp = "has been ignored"
+  )
+  expect_equal(names(data), toupper(names(data)))
+})
+
+
+test_that("lower_vars = TRUE warning on hierarchical .dat.gz", {
+  ddi <- read_ipums_ddi(ipums_example("cps_00010.xml"))
+
+  expect_warning(
+    data <- read_ipums_micro_list(ddi, verbose = FALSE, lower_vars = TRUE),
+    regexp = "has been ignored"
+  )
+  expect_equal(names(data$PERSON), toupper(names(data$PERSON)))
+})
+
+
+test_that("lower_vars arg works on .csv.gz file", {
+  ddi <- read_ipums_ddi(ipums_example("cps_00006.xml"), lower_vars = TRUE)
+  data <- read_ipums_micro(
+    ddi,
+    data_file = ipums_example("cps_00006.csv.gz"),
+    verbose = FALSE
+  )
+
+  expect_equal(names(data), tolower(names(data)))
+
+  data <- read_ipums_micro(
+    ddi = ipums_example("cps_00006.xml"),
+    data_file = ipums_example("cps_00006.csv.gz"),
+    verbose = FALSE,
+    lower_vars = TRUE
+  )
+
+  expect_equal(names(data), tolower(names(data)))
+})
+
+test_that("lower_vars arg works on chunked rectangular .dat.gz", {
+  ddi <- read_ipums_ddi(ipums_example("cps_00006.xml"))
+
+  expect_warning(
+    data <- read_ipums_micro_chunked(
+      ddi,
+      IpumsDataFrameCallback$new(function(x, ...) x[x$STATEFIP == 19, ]),
+      verbose = FALSE,
+      lower_vars = TRUE
+    ),
+    regexp = "has been ignored"
+  )
+  expect_equal(names(data), toupper(names(data)))
+
+  ddi <- read_ipums_ddi(ipums_example("cps_00006.xml"), lower_vars = TRUE)
+  data <- read_ipums_micro_chunked(
+    ddi,
+    IpumsDataFrameCallback$new(function(x, ...) x[x$statefip == 19, ]),
+    verbose = FALSE
+  )
+
+  expect_equal(names(data), tolower(names(data)))
+
+  data <- read_ipums_micro_chunked(
+    ipums_example("cps_00006.xml"),
+    IpumsDataFrameCallback$new(function(x, ...) x[x$statefip == 19, ]),
+    verbose = FALSE,
+    lower_vars = TRUE
+  )
+
+  expect_equal(names(data), tolower(names(data)))
+
+})
+
+
+test_that("lower_vars arg works on chunked hierarchical .dat.gz", {
+  ddi <- read_ipums_ddi(ipums_example("cps_00010.xml"))
+
+  expect_warning(
+    data <- read_ipums_micro_list_chunked(
+      ddi,
+      IpumsListCallback$new(function(x, ...) x),
+      verbose = FALSE,
+      lower_vars = TRUE
+    ),
+    regexp = "has been ignored"
+  )
+  data_combined <- list(
+    HOUSEHOLD = ipums_bind_rows(
+      lapply(data, function(x) x$HOUSEHOLD)
+    ),
+    PERSON = ipums_bind_rows(
+      lapply(data, function(x) x$PERSON)
+    )
+  )
+  expect_equal(names(data_combined$PERSON), toupper(names(data_combined$PERSON)))
+
+
+  ddi <- read_ipums_ddi(ipums_example("cps_00010.xml"), lower_vars = TRUE)
+  data <- read_ipums_micro_list_chunked(
+    ddi,
+    IpumsListCallback$new(function(x, ...) x),
+    verbose = FALSE
+  )
+  data_combined <- list(
+    HOUSEHOLD = ipums_bind_rows(
+      lapply(data, function(x) x$HOUSEHOLD)
+    ),
+    PERSON = ipums_bind_rows(
+      lapply(data, function(x) x$PERSON)
+    )
+  )
+
+  expect_equal(names(data_combined$PERSON), tolower(names(data_combined$PERSON)))
+
+  data <- read_ipums_micro_list_chunked(
+    ddi = ipums_example("cps_00010.xml"),
+    IpumsListCallback$new(function(x, ...) x),
+    verbose = FALSE,
+    lower_vars = TRUE
+  )
+  data_combined <- list(
+    HOUSEHOLD = ipums_bind_rows(
+      lapply(data, function(x) x$HOUSEHOLD)
+    ),
+    PERSON = ipums_bind_rows(
+      lapply(data, function(x) x$PERSON)
+    )
+  )
+
+  expect_equal(names(data_combined$PERSON), tolower(names(data_combined$PERSON)))
+})
+
+test_that("lower_vars arg works on chunked .csv.gz file", {
+  ddi <- read_ipums_ddi(ipums_example("cps_00006.xml"), lower_vars = TRUE)
+  data <- read_ipums_micro_chunked(
+    ddi,
+    IpumsDataFrameCallback$new(function(x, ...) x[x$STATEFIP == 19, ]),
+    data_file = ipums_example("cps_00006.csv.gz"),
+    verbose = FALSE
+  )
+
+  expect_equal(names(data), tolower(names(data)))
+
+  data <- read_ipums_micro_chunked(
+    ddi = ipums_example("cps_00006.xml"),
+    IpumsDataFrameCallback$new(function(x, ...) x[x$STATEFIP == 19, ]),
+    data_file = ipums_example("cps_00006.csv.gz"),
+    verbose = FALSE,
+    lower_vars = TRUE
+  )
+
+  expect_equal(names(data), tolower(names(data)))
+})
+
+test_that("lower_vars arg works with _yield on rectangular .dat.gz", {
+  ddi <- read_ipums_ddi(ipums_example("cps_00006.xml"))
+
+  expect_warning(
+    cps_yield_source <- read_ipums_micro_yield(
+      ddi,
+      verbose = FALSE,
+      lower_vars = TRUE
+    ),
+    regexp = "has been ignored"
+  )
+  cps_yield <- list()
+  while(!cps_yield_source$is_done()) {
+    cps_yield[[length(cps_yield) + 1]] <- cps_yield_source$yield(1000)
+  }
+  data <- ipums_bind_rows(cps_yield)
+
+  expect_equal(names(data), toupper(names(data)))
+
+
+  ddi <- read_ipums_ddi(ipums_example("cps_00006.xml"), lower_vars = TRUE)
+  cps_yield_source <- read_ipums_micro_yield(
+    ddi,
+    verbose = FALSE
+  )
+  cps_yield <- list()
+  while(!cps_yield_source$is_done()) {
+    cps_yield[[length(cps_yield) + 1]] <- cps_yield_source$yield(1000)
+  }
+  data <- ipums_bind_rows(cps_yield)
+
+  expect_equal(names(data), tolower(names(data)))
+
+
+  cps_yield_source <- read_ipums_micro_yield(
+    ddi = ipums_example("cps_00006.xml"),
+    verbose = FALSE,
+    lower_vars = TRUE
+  )
+  cps_yield <- list()
+  while(!cps_yield_source$is_done()) {
+    cps_yield[[length(cps_yield) + 1]] <- cps_yield_source$yield(1000)
+  }
+  data <- ipums_bind_rows(cps_yield)
+
+  expect_equal(names(data), tolower(names(data)))
+
+})
+
+
+test_that("lower_vars arg works with _yield on hierarchical .dat.gz", {
+  ddi <- read_ipums_ddi(ipums_example("cps_00010.xml"))
+
+  expect_warning(
+    cps_yield_source <- read_ipums_micro_list_yield(
+      ddi,
+      verbose = FALSE,
+      lower_vars = TRUE
+    ),
+    regexp = "has been ignored"
+  )
+  cps_yield <- list()
+  while(!cps_yield_source$is_done()) {
+    cps_yield[[length(cps_yield) + 1]] <- cps_yield_source$yield(1000)
+  }
+  data <- list(
+    HOUSEHOLD = ipums_bind_rows(
+      lapply(cps_yield, function(x) x$HOUSEHOLD)
+    ),
+    PERSON = ipums_bind_rows(
+      lapply(cps_yield, function(x) x$PERSON)
+    )
+  )
+
+  expect_equal(names(data$PERSON), toupper(names(data$PERSON)))
+
+
+  ddi <- read_ipums_ddi(ipums_example("cps_00010.xml"), lower_vars = TRUE)
+  cps_yield_source <- read_ipums_micro_list_yield(
+    ddi,
+    verbose = FALSE
+  )
+  cps_yield <- list()
+  while(!cps_yield_source$is_done()) {
+    cps_yield[[length(cps_yield) + 1]] <- cps_yield_source$yield(1000)
+  }
+  data <- list(
+    HOUSEHOLD = ipums_bind_rows(
+      lapply(cps_yield, function(x) x$HOUSEHOLD)
+    ),
+    PERSON = ipums_bind_rows(
+      lapply(cps_yield, function(x) x$PERSON)
+    )
+  )
+
+  expect_equal(names(data$PERSON), tolower(names(data$PERSON)))
+
+  cps_yield_source <- read_ipums_micro_list_yield(
+    ddi = ipums_example("cps_00010.xml"),
+    verbose = FALSE,
+    lower_vars = TRUE
+  )
+  cps_yield <- list()
+  while(!cps_yield_source$is_done()) {
+    cps_yield[[length(cps_yield) + 1]] <- cps_yield_source$yield(1000)
+  }
+  data <- list(
+    HOUSEHOLD = ipums_bind_rows(
+      lapply(cps_yield, function(x) x$HOUSEHOLD)
+    ),
+    PERSON = ipums_bind_rows(
+      lapply(cps_yield, function(x) x$PERSON)
+    )
+  )
+
+  expect_equal(names(data$PERSON), tolower(names(data$PERSON)))
+})

--- a/tests/testthat/test_micro_yield.r
+++ b/tests/testthat/test_micro_yield.r
@@ -95,3 +95,14 @@ test_that(
 
     expect_equal(cps_yield, cps_chunked)
   })
+
+test_that("read_ipums_micro_yield can't read from .csv file", {
+  expect_error(
+    cps_yield_source <- read_ipums_micro_yield(
+      ddi = ipums_example("cps_00006.xml"),
+      data_file = ipums_example("cps_00006.csv.gz"),
+      verbose = FALSE
+    ),
+    regexp = "does not support"
+  )
+})


### PR DESCRIPTION
Resolves #56, which highlighted the confusing behavior of the lower_vars argument to `read_ipums_micro()`. This PR addresses this issue by adding detail to the argument description, and by throwing a warning when the lower_vars argument will be ignored. The PR also adds lower_vars support to the chunked reading functions, and fixes a bug that caused an error when lower_vars was set to true and the user supplied a .csv(.gz) file, and (on a different topic) makes it more clear in the documentation for and error message coming from the `_yield` functions that these functions don't work with .csv(.gz) data files.