### PR TITLE
Fix for upcoming haven 2.3.0 release

### DIFF
--- a/R/lbl_helpers.r
+++ b/R/lbl_helpers.r
@@ -247,9 +247,8 @@ lbl_define <- function(x, ...) {
   attr(x, "labels") <- purrr::set_names(unique_x, tmp_lbls)
   x <- lbl_relabel(x, ...)
   label_is_na <- is.na(names(attr(x, "labels")))
-  attr(x, "labels") <- attr(x, "labels")[!label_is_na]
-  attr(x, "class") <- "haven_labelled"
-  x
+
+  haven::labelled(x, labels = attr(x, "labels")[!label_is_na])
 }
 
 


### PR DESCRIPTION
This fixes one failing test, since haven's `labelled` class now inherits from `vctrs_vectr` and `double`. You may need other changes in your code, but this will allow your package to pass R CMD check on CRAN.